### PR TITLE
Fix Envoy SHA comment to correct date

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,7 @@ bind(
     actual = "//external:ssl",
 )
 
-ENVOY_SHA = "352fe35845388333917423e9d5d4e5c3d4872291"  # Jan 16, 2017
+ENVOY_SHA = "352fe35845388333917423e9d5d4e5c3d4872291"  # Jan 16, 2018
 
 http_archive(
     name = "envoy",


### PR DESCRIPTION
**What this PR does / why we need it**:

The comment on the Envoy SHA mentioned the wrong year, so I thought Envoy was quite old.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
